### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,9 @@ export function createApp(
 ): Application {
     const config = createProxyConfig(options);
     const { logger } = config;
-    logger.debug('Configuration:', config);
+    // Sanitize config before logging to avoid leaking sensitive information
+    const sanitizedConfig = { ...config, unleashApiToken: '[REDACTED]' };
+    logger.debug('Configuration:', sanitizedConfig);
     const client =
         unleashClient ||
         (options.clientMode === 'new'


### PR DESCRIPTION
Potential fix for [https://github.com/checkout-anywhere/unleash-proxy/security/code-scanning/9](https://github.com/checkout-anywhere/unleash-proxy/security/code-scanning/9)

To fix the problem, we need to ensure that sensitive fields (such as `unleashApiToken`) are not logged when the configuration object is passed to the logger. The best way to do this is to sanitize the configuration object before logging it, by removing or masking sensitive fields. Specifically, in `src/app.ts`, before calling `logger.debug('Configuration:', config);`, we should create a sanitized copy of the `config` object with sensitive fields (like `unleashApiToken`) removed or replaced with a placeholder (e.g., `'[REDACTED]'`). This approach preserves the usefulness of the log message while protecting sensitive data.

**Required changes:**
- In `src/app.ts`, before logging the configuration, create a sanitized version of the `config` object with sensitive fields redacted.
- Update the call to `logger.debug` to use the sanitized configuration object.

No changes are needed in the logger implementation itself, as the issue is with what is being passed to it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
